### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,28 @@
+# Build on Alpine
+FROM alpine AS build
+
+# Add build dependencies
+RUN apk add npm
+
+# Copy in source files
+WORKDIR /build/
+COPY . /build/
+
+# Install node deps and build
+RUN npm i && npm run build
+
+# Start fresh and copy in the built app
 FROM alpine
+WORKDIR /app/
+COPY --from=build /build/dist/ ./
+COPY --from=build /build/node_modules/ ./node_modules/
 
-RUN apk add nodejs npm git
+# Add runtime dependencies
+RUN apk add nodejs
 
-WORKDIR /app
-COPY . /app/
-
-RUN npm i
-
+# Set and expose the default port
 ENV PORT=28104
 EXPOSE 28104
 
-CMD ["npm", "run", "serve"]
+# Start the server
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+RUN apk add nodejs npm git
+
+WORKDIR /app
+COPY . /app/
+
+RUN npm i
+
+CMD ["npm", "run", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ COPY . /app/
 
 RUN npm i
 
+ENV PORT=28104
+EXPOSE 28104
+
 CMD ["npm", "run", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,16 @@ COPY . /build/
 # Install node deps and build
 RUN npm i && npm run build
 
-# Start fresh and copy in the built app
+# Start fresh
 FROM alpine
 WORKDIR /app/
-COPY --from=build /build/dist/ ./
-COPY --from=build /build/node_modules/ ./node_modules/
 
 # Add runtime dependencies
 RUN apk add nodejs
+
+# Copy in the built app
+COPY --from=build /build/dist/ ./
+COPY --from=build /build/node_modules/ ./node_modules/
 
 # Set and expose the default port
 ENV PORT=28104

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": false,
-    "lib": ["es2017"],
+    "lib": ["es2017", "dom"],
     "rootDir": "src",
     "resolveJsonModule": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Adds a Dockerfile for easy deployment wherever you want to handle your Up->YNAB integration needs.

Note this also tweaks the TypeScript compiler config to assume that the DOM library will be present at runtime, as the YNAB library uses a `Request` object. See the 540fdc18f7da9650fa3c4d164e390ec83ec8adbc for details.